### PR TITLE
fix rp2040-zero footprint

### DIFF
--- a/mcu.pretty/rp2040-zero-smd.kicad_mod
+++ b/mcu.pretty/rp2040-zero-smd.kicad_mod
@@ -1,40 +1,315 @@
-(footprint "rp2040-zero-smd" (version 20211014) (generator pcbnew)
-  (layer "F.Cu")
-  (tedit 61DA8723)
-  (attr smd exclude_from_pos_files)
-  (fp_text reference "U?" (at -16.3989 -16.53268) (layer "F.SilkS") hide
-    (effects (font (size 0.889 0.889) (thickness 0.1016)))
-    (tstamp 1c479411-a194-4685-8eeb-e81966c16c7f)
-  )
-  (fp_text value "rp2040-zero-smd" (at -16.8434 -5.54718) (layer "F.SilkS") hide
-    (effects (font (size 0.6096 0.6096) (thickness 0.0762)))
-    (tstamp d811e9ac-fc59-4c9b-8d93-83a5a9c048b6)
-  )
-  (fp_rect (start -9 -11.75) (end 9 11.75) (layer "Dwgs.User") (width 0.12) (fill none) (tstamp 180245d9-4a3f-4d1b-adcc-b4eafac722e0))
-  (fp_line (start -6 9.25) (end 6 9.25) (layer "Edge.Cuts") (width 0.12) (tstamp 57e128ae-5e07-4818-9f5a-1cee0e65c680))
-  (fp_line (start 6 9.25) (end 6 -11.75) (layer "Edge.Cuts") (width 0.12) (tstamp 96e87ac2-5565-47ab-ae62-263f85b93211))
-  (fp_line (start -6 -11.75) (end -6 9.25) (layer "Edge.Cuts") (width 0.12) (tstamp b4450c83-6da6-4393-a892-92bf8cbec8aa))
-  (pad "1" smd oval (at 7.62 -10.16 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 4c6510d9-017e-4c47-82ba-5105026c6f89))
-  (pad "2" smd oval (at 7.62 -7.62 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 68f7174d-ce7a-41b4-89f8-dd7e3ded57a1))
-  (pad "3" smd oval (at 7.62 -5.08 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp da7e6488-201f-4286-b86a-ca5aced3697a))
-  (pad "4" smd oval (at 7.62 -2.54 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 2b7c4f37-42c0-4571-a44b-b808484d3d74))
-  (pad "5" smd oval (at 7.62 0 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp abe3c03e-744a-4406-8e50-6a10745f0c43))
-  (pad "6" smd oval (at 7.62 2.54 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 771cb5c1-62ba-4cca-999e-cdcbe417213c))
-  (pad "7" smd oval (at 7.62 5.08 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 6a1ae8ee-dea6-4015-b83e-baf8fcdfaf0f))
-  (pad "8" smd oval (at 7.62 7.62 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 5a319d05-1a85-43fe-a179-ebcee7212a03))
-  (pad "9" smd oval (at 7.62 10.16 180) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 2e6b1f7e-e4c3-43a1-ae90-c85aa40696d5))
-  (pad "10" smd oval (at 5.08 10.16 90) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 9eb142f5-c818-4799-9b6e-f56193c12346))
-  (pad "11" smd oval (at 2.54 10.16 90) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 70abf340-8b3e-403e-a5e2-d8f35caa2f87))
-  (pad "12" smd oval (at 0 10.16 90) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 4f2f68c4-6fa0-45ce-b5c2-e911daddcd12))
-  (pad "13" smd oval (at -2.54 10.16 90) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 47993d80-a37e-426e-90c9-fd54b49ed166))
-  (pad "14" smd oval (at -5.08 10.16 90) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 0a4f1792-568b-402b-9700-fd4b01130ff8))
-  (pad "15" smd oval (at -7.62 10.16) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 867e444b-3681-4baf-9d08-1188c3544771))
-  (pad "16" smd oval (at -7.62 7.62) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 9c4384c0-9a57-4262-8711-eec9b8ecb4c6))
-  (pad "17" smd oval (at -7.62 5.08) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a20b891b-a240-411f-9914-9ac989f03074))
-  (pad "18" smd oval (at -7.62 2.54) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 761a1a33-98a4-41af-9660-18c12d51b442))
-  (pad "19" smd oval (at -7.62 0) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 2caa1d4c-02f2-443a-a145-dc5854878c73))
-  (pad "20" smd oval (at -7.62 -2.54) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 1b7a2775-7631-4d4f-8b27-ab588adb3b7d))
-  (pad "21" smd oval (at -7.62 -5.08) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 75b890e6-df6d-4a6e-acaa-0870cda0d189))
-  (pad "22" smd oval (at -7.62 -7.62) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp e4d9ec61-16f7-410d-891d-89481964ef82))
-  (pad "23" smd oval (at -7.62 -10.16) (size 2.5 1.5) (drill (offset -0.5 0)) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 8a11f86e-586e-495d-a11e-a1e650589934))
+(footprint "rp2040-zero-smd"
+	(version 20240108)
+	(generator "pcbnew")
+	(generator_version "8.0")
+	(layer "F.Cu")
+	(property "Reference" "U?"
+		(at -16.3989 -16.53268 0)
+		(layer "F.SilkS")
+		(hide yes)
+		(uuid "1c479411-a194-4685-8eeb-e81966c16c7f")
+		(effects
+			(font
+				(size 0.889 0.889)
+				(thickness 0.1016)
+			)
+		)
+	)
+	(property "Value" "rp2040-zero-smd"
+		(at -16.8434 -5.54718 0)
+		(layer "F.SilkS")
+		(hide yes)
+		(uuid "d811e9ac-fc59-4c9b-8d93-83a5a9c048b6")
+		(effects
+			(font
+				(size 0.6096 0.6096)
+				(thickness 0.0762)
+			)
+		)
+	)
+	(property "Footprint" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "534cddc9-d132-44f1-9a19-06db2df6bf6c")
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+	)
+	(property "Datasheet" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "3c3809e1-8c31-4145-9fc5-398a143d713b")
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+	)
+	(property "Description" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "8b623412-b458-42f1-9dfe-7a148342056b")
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+	)
+	(attr smd exclude_from_pos_files)
+	(fp_rect
+		(start -9 -11.75)
+		(end 9 11.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(fill none)
+		(layer "Dwgs.User")
+		(uuid "180245d9-4a3f-4d1b-adcc-b4eafac722e0")
+	)
+	(fp_line
+		(start -6 -11.75)
+		(end -6 8.89)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "b4450c83-6da6-4393-a892-92bf8cbec8aa")
+	)
+	(fp_line
+		(start -6 8.89)
+		(end 6 8.89)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "57e128ae-5e07-4818-9f5a-1cee0e65c680")
+	)
+	(fp_line
+		(start 6 8.89)
+		(end 6 -11.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "96e87ac2-5565-47ab-ae62-263f85b93211")
+	)
+	(pad "1" smd oval
+		(at 7.62 -10.16 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "4c6510d9-017e-4c47-82ba-5105026c6f89")
+	)
+	(pad "2" smd oval
+		(at 7.62 -7.62 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "68f7174d-ce7a-41b4-89f8-dd7e3ded57a1")
+	)
+	(pad "3" smd oval
+		(at 7.62 -5.08 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "da7e6488-201f-4286-b86a-ca5aced3697a")
+	)
+	(pad "4" smd oval
+		(at 7.62 -2.54 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "2b7c4f37-42c0-4571-a44b-b808484d3d74")
+	)
+	(pad "5" smd oval
+		(at 7.62 0 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "abe3c03e-744a-4406-8e50-6a10745f0c43")
+	)
+	(pad "6" smd oval
+		(at 7.62 2.54 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "771cb5c1-62ba-4cca-999e-cdcbe417213c")
+	)
+	(pad "7" smd oval
+		(at 7.62 5.08 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "6a1ae8ee-dea6-4015-b83e-baf8fcdfaf0f")
+	)
+	(pad "8" smd oval
+		(at 7.62 7.62 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "5a319d05-1a85-43fe-a179-ebcee7212a03")
+	)
+	(pad "9" smd oval
+		(at 7.62 10.16 180)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "2e6b1f7e-e4c3-43a1-ae90-c85aa40696d5")
+	)
+	(pad "10" smd oval
+		(at 5.08 10.16 90)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "9eb142f5-c818-4799-9b6e-f56193c12346")
+	)
+	(pad "11" smd oval
+		(at 2.54 10.16 90)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "70abf340-8b3e-403e-a5e2-d8f35caa2f87")
+	)
+	(pad "12" smd oval
+		(at 0 10.16 90)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "4f2f68c4-6fa0-45ce-b5c2-e911daddcd12")
+	)
+	(pad "13" smd oval
+		(at -2.54 10.16 90)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "47993d80-a37e-426e-90c9-fd54b49ed166")
+	)
+	(pad "14" smd oval
+		(at -5.08 10.16 90)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "0a4f1792-568b-402b-9700-fd4b01130ff8")
+	)
+	(pad "15" smd oval
+		(at -7.62 10.16)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "867e444b-3681-4baf-9d08-1188c3544771")
+	)
+	(pad "16" smd oval
+		(at -7.62 7.62)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "9c4384c0-9a57-4262-8711-eec9b8ecb4c6")
+	)
+	(pad "17" smd oval
+		(at -7.62 5.08)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "a20b891b-a240-411f-9914-9ac989f03074")
+	)
+	(pad "18" smd oval
+		(at -7.62 2.54)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "761a1a33-98a4-41af-9660-18c12d51b442")
+	)
+	(pad "19" smd oval
+		(at -7.62 0)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "2caa1d4c-02f2-443a-a145-dc5854878c73")
+	)
+	(pad "20" smd oval
+		(at -7.62 -2.54)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "1b7a2775-7631-4d4f-8b27-ab588adb3b7d")
+	)
+	(pad "21" smd oval
+		(at -7.62 -5.08)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "75b890e6-df6d-4a6e-acaa-0870cda0d189")
+	)
+	(pad "22" smd oval
+		(at -7.62 -7.62)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "e4d9ec61-16f7-410d-891d-89481964ef82")
+	)
+	(pad "23" smd oval
+		(at -7.62 -10.16)
+		(size 2.5 1.5)
+		(drill
+			(offset -0.5 0)
+		)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(uuid "8a11f86e-586e-495d-a11e-a1e650589934")
+	)
 )


### PR DESCRIPTION
This moves the cutout for `rp2040-zero-smd.kicad_mod` out of the protected space of the pads

![grafik](https://github.com/crides/kleeb/assets/93924020/30bfd3b6-59e5-48e6-a596-746e8ea5c86d)

Other RP2040-Zero would need this as well.
Unfortunately the new version of KiCad 8.0 reformatted the whole file 